### PR TITLE
Use embedded version info

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -69,6 +69,11 @@ jobs:
       - uses: actions/checkout@v3
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
+      - name: Replace commit SHA
+        run: |
+          short_sha=$(git rev-parse --short HEAD)
+          sed -i s/SHORT_SHA/$short_sha/g fly.toml
+
       - run: flyctl deploy --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_TOKEN }}

--- a/fly.toml
+++ b/fly.toml
@@ -7,7 +7,7 @@ app = "wafflehacks-mailer"
 primary_region = "yyz"
 
 [build]
-  image = "public.ecr.aws/wafflehacks/mailer:main"
+  image = "public.ecr.aws/wafflehacks/mailer:sha-SHORT_SHA"
 
 [deploy]
   strategy = "rolling"

--- a/fly.toml
+++ b/fly.toml
@@ -31,7 +31,7 @@ primary_region = "yyz"
     type = "http"
     port = 8000
     method = "get"
-    path = "/ping"
+    path = "/health"
     protocol = "http"
 
     grace_period = "10s"

--- a/http/http.go
+++ b/http/http.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/WaffleHacks/mailer/daemon"
 	"github.com/WaffleHacks/mailer/logging"
+	"github.com/WaffleHacks/mailer/version"
 )
 
 var (
@@ -43,6 +44,7 @@ func New(address string, queue chan daemon.Message) *http.Server {
 	router.Use(middleware.Recoverer)
 	router.Use(middleware.Heartbeat("/ping"))
 
+	router.Get("/health", healthcheck)
 	router.Post("/send", m.send)
 	router.Post("/send/batch", m.sendBatch)
 	router.Post("/send/template", m.sendTemplate)
@@ -57,6 +59,11 @@ func New(address string, queue chan daemon.Message) *http.Server {
 			otelhttp.WithServerName(serverName()),
 		),
 	}
+}
+
+func healthcheck(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(version.Printable))
 }
 
 func serverName() string {

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -3,6 +3,8 @@ package logging
 import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+
+	"github.com/WaffleHacks/mailer/version"
 )
 
 var (
@@ -44,11 +46,16 @@ func New(level zap.AtomicLevel, development bool) (*zap.Logger, error) {
 		OutputPaths:       []string{"stdout"},
 		ErrorOutputPaths:  []string{"stdout"},
 	}
-	logger, err := config.Build()
+	base, err := config.Build()
 	if err != nil {
 		return nil, err
 	}
 
+	logger := base.With(
+		zap.String("build.version", version.Commit),
+		zap.Bool("build.dirty", version.Dirty),
+		zap.String("build.go", version.GoVersion),
+	)
 	zap.ReplaceGlobals(logger)
 	developmentOption = development
 

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,39 @@
+package version
+
+import (
+	"fmt"
+	"runtime/debug"
+	"strconv"
+)
+
+var (
+	Commit    string
+	Dirty     bool
+	GoVersion string
+
+	// Printable contains all the version information as a new-line separated list
+	Printable string
+)
+
+func init() {
+	info, ok := debug.ReadBuildInfo()
+	if ok {
+		GoVersion = info.GoVersion
+		for _, setting := range info.Settings {
+			switch setting.Key {
+			case "vcs.revision":
+				Commit = setting.Value[:7]
+			case "vcs.modified":
+				Dirty, _ = strconv.ParseBool(setting.Value)
+			}
+		}
+	} else {
+		Commit = "unknown"
+		Dirty = true
+		GoVersion = "unknown"
+	}
+
+	Printable = fmt.Sprintf(`commit: %s
+dirty:  %t
+go:     %s`, Commit, Dirty, GoVersion)
+}


### PR DESCRIPTION
Use the embedded version information in the binary to reference in the logger, OpenTelemetry, and health checks. This also updates the fly deployment to use the short commit SHA over the branch name so we can quickly determine what version is running.